### PR TITLE
MWS.orders.next don`t clear last request next_token

### DIFF
--- a/spec/ruby-mws/api/base_spec.rb
+++ b/spec/ruby-mws/api/base_spec.rb
@@ -38,5 +38,20 @@ describe MWS::API::Base do
       lambda{ @api.list_fake_objects }.should raise_error TestWorksError
     end
   end
-  
+
+  context "next token should be nil" do
+
+    it "first request then no next_token" do
+      @api.after_response
+      @api.next_token.should be_nil
+    end
+
+    it "sencond request then no next_token" do
+      @api.instance_variable_set(:@next, {token: 'last request token'})
+      @api.after_response
+      @api.next_token.should be_nil
+    end
+
+  end
+
 end


### PR DESCRIPTION
In [api/base.rb:50](https://github.com/elyngved/ruby-mws/blob/master/lib/ruby-mws/api/base.rb#L50).

If i need 2 request to get all orders, after success run one times `mws.orders.next` even the last request do not return a 'next_token' the `@next[:token]` will persist the last request`s token, code like below will loop forever.

``` ruby
save_or_update_orders(response.orders)
while mws.orders.has_next?
  puts 'into next page...'
  save_or_update_orders(mws.orders.next.orders)
end
```

Because if next reponse do not have `next_token` then 

``` ruby
if @response.respond_to?(:next_token) and @next[:token] = @response.next_token
```

will not execute `@next[:token] = ...`
