### PR TITLE
Replies with a single order were not an Array

### DIFF
--- a/lib/ruby-mws/api/order.rb
+++ b/lib/ruby-mws/api/order.rb
@@ -10,7 +10,7 @@ module MWS
           :order_status => "OrderStatus.Status"
         },
         :mods => [
-          lambda {|r| r.orders = r.orders.order if r.orders}
+          lambda {|r| r.orders = [r.orders.order].flatten if r.orders},
         ]
 
       def_request [:list_order_items, :list_order_items_by_next_token],


### PR DESCRIPTION
Single order replies where not enclosed in an array.  This applies
the technique that's used on order_lines to the orders.

This crashed our import scripts over Christmas day.  I'm guessing it's a slow sales day for Amazon since we received only a single order.
